### PR TITLE
Fix account ID param

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,5 @@
 1.0.0 September, 2018
   - Initial release with disputes API
+
+1.1.0 September, 2018
+  - The `account_id` param should be used instead of the `user_id` param

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this dependency to your project's POM:
 <dependency>
   <groupId>com.chargehound</groupId>
   <artifactId>chargehound-java</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -22,7 +22,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.chargehound:chargehound-java:1.0.0"
+compile "com.chargehound:chargehound-java:1.1.0"
 ```
 
 ### Others

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.chargehound
-VERSION_NAME=1.0.0
+VERSION_NAME=1.1.0
 
 POM_URL=https://github.com/chargehound/chargehound-java
 POM_SCM_URL=git@github.com:chargehound/chargehound-java.git

--- a/src/main/java/com/chargehound/Chargehound.java
+++ b/src/main/java/com/chargehound/Chargehound.java
@@ -17,7 +17,7 @@ public class Chargehound {
   private String key;
   private String protocol = "https://";
 
-  public static final String VERSION = "1.0.0";
+  public static final String VERSION = "1.1.0";
   public Disputes disputes;
 
   // Creates a new chargehound client with the specified api key and the default configuration.

--- a/src/main/java/com/chargehound/models/Dispute.java
+++ b/src/main/java/com/chargehound/models/Dispute.java
@@ -98,8 +98,8 @@ public class Dispute extends GenericJson {
   @Key("statement_descriptor")
   public String statementDescriptor;
   // The account id for Connected accounts that are charged directly through Stripe (if any)
-  @Key("user_id")
-  public String userId;
+  @Key("account_id")
+  public String accountId;
   // The kind for the dispute, 'chargeback', 'retrieval' or 'pre_arbitration'.
   @Key("kind")
   public String kind;
@@ -155,8 +155,8 @@ public class Dispute extends GenericJson {
   public static class UpdateParams extends GenericJson {
     // Set the account id for Connected accounts that are charged directly through Stripe.
     // (optional)
-    @Key("user_id")
-    public String userId;
+    @Key("account_id")
+    public String accountId;
     // Id of the connected account for this dispute (if multiple accounts are connected)
     // (optional)
     @Key("account")
@@ -184,7 +184,7 @@ public class Dispute extends GenericJson {
     public UpdateParams() {}
 
     private UpdateParams(
-        final String userId,
+        final String accountId,
         final String account,
         final Boolean force,
         final Boolean queue,
@@ -193,7 +193,7 @@ public class Dispute extends GenericJson {
         final List<Product> products,
         final String referenceUrl
     ) {
-      this.userId = userId;
+      this.accountId = accountId;
       this.account = account;
       this.force = force;
       this.queue = queue;
@@ -204,7 +204,7 @@ public class Dispute extends GenericJson {
     }
 
     public static class Builder {
-      private String userId;
+      private String accountId;
       private String account;
       private Boolean force;
       private Boolean queue;
@@ -213,8 +213,8 @@ public class Dispute extends GenericJson {
       private List<Product> products;
       private String referenceUrl;
 
-      public Builder userId(final String userId) {
-        this.userId = userId;
+      public Builder accountId(final String accountId) {
+        this.accountId = accountId;
         return this;
       }
 
@@ -259,7 +259,7 @@ public class Dispute extends GenericJson {
        */
       public UpdateParams finish() {
         return new UpdateParams(
-          this.userId,
+          this.accountId,
           this.account,
           this.force,
           this.queue,
@@ -351,8 +351,8 @@ public class Dispute extends GenericJson {
     public List<Product> products;
     // Set the account id for Connected accounts that are charged directly through Stripe.
     // (optional)
-    @Key("user_id")
-    public String userId;
+    @Key("account_id")
+    public String accountId;
     // Set the kind for the dispute, 'chargeback', 'retrieval' or 'pre_arbitration'.
     // (optional)
     @Key("kind")
@@ -393,7 +393,7 @@ public class Dispute extends GenericJson {
         final String template,
         final Map<String, Object> fields,
         final List<Product> products,
-        final String userId,
+        final String accountId,
         final String kind,
         final Boolean submit,
         final Boolean queue,
@@ -422,7 +422,7 @@ public class Dispute extends GenericJson {
       this.template = template;
       this.fields = fields;
       this.products = products;
-      this.userId = userId;
+      this.accountId = accountId;
       this.kind = kind;
       this.submit = submit;
       this.queue = queue;
@@ -453,7 +453,7 @@ public class Dispute extends GenericJson {
       private String template;
       private Map<String, Object> fields;
       private List<Product> products;
-      private String userId;
+      private String accountId;
       private String kind;
       private Boolean submit;
       private Boolean queue;
@@ -559,8 +559,8 @@ public class Dispute extends GenericJson {
         return this;
       }
 
-      public Builder userId(final String userId) {
-        this.userId = userId;
+      public Builder accountId(final String accountId) {
+        this.accountId = accountId;
         return this;
       }
 
@@ -628,7 +628,7 @@ public class Dispute extends GenericJson {
           this.template,
           this.fields,
           this.products,
-          this.userId,
+          this.accountId,
           this.kind,
           this.submit,
           this.queue,


### PR DESCRIPTION
The `account_id` param should be used instead of the `user_id` param.

This should technically be a major version bump (because it's backward incompatible), but b/c the lib is so new and no one uses it yet, I'm going to say this is a minor version bump.