### PR TITLE
Remove unneeded flag. Default javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,12 +52,6 @@ task javadocJar(type: Jar) {
   classifier = 'javadoc'
 }
 
-javadoc {
-  if(JavaVersion.current().isJava9Compatible()) {
-    options.addBooleanOption('html4', true)
-  }
-}
-
 artifacts {
   archives javadocJar, sourcesJar
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,3 @@
  */
 
 rootProject.name = 'chargehound-java'
-
-enableFeaturePreview('STABLE_PUBLISHING')
-


### PR DESCRIPTION
Seems like STABLE_PUBLISHING is not the default behavior. "enableFeaturePreview('STABLE_PUBLISHING') has been deprecated. This is scheduled to be removed in Gradle 6.0. The feature flag is no longer relevant, please remove it from your settings file." 

Also removing the "html4" flag it's the javadoc default and was causing issues. We don't use HTML in the javadoc comments yet anyway.